### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:24.7-trixie
+
+WORKDIR /app
+
+# playwright dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnspr4 \
+    libnss3 \
+    libdbus-1-3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libxkbcommon0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . /app 
+
+# get deps
+RUN npm ci 
+RUN npm run deps
+
+# start prometheus exporter
+CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . /app 
 
 # get deps
-RUN npm ci 
-RUN npm run deps
+RUN npm ci && npm run deps
 
 # start prometheus exporter
 CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now zyxel-prometheus-exporter.service
 ```
 
+## Running with Docker
+
+```sh
+docker build -t zyxel-prometheus-exporter .
+docker run --rm \
+    --name zyxel-prometheus-exporter \
+    -p 3000:3000 \
+    -e SWITCH_IP=192.168.1.10 \
+    -e 'SWITCH_PASSWORD=superSecretPassword1' \
+    zyxel-prometheus-exporter
+```


### PR DESCRIPTION
Hey, thanks for this project! I've long had it on my todo list to create an exporter for these switches without SNMP support (I have two) but never took the time. This worked perfectly!

I run everything on a bare metal Kubernetes cluster locally so I need everything to be in a container. I thought it might be useful to share this back with you so that others could benefit from it as well.

Also, I would suggest adding a `LICENSE` file and perhaps a `CONTRIBUTING` file as I am just assuming here that you are open to pull requests.